### PR TITLE
sw: change hex from words to bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ $(SW):
 ## Build the helloworld software
 software: $(SW)
 
+sw: $(SW)
+
 .PHONY: software
 
 ##################

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -55,7 +55,7 @@ $(BINDIR)/%.dump: $(BINDIR)/%.elf
 	$(RISCV_OBJDUMP) -D -s $< >$@
 
 $(BINDIR)/%.hex: $(BINDIR)/%.elf
-	$(RISCV_OBJCOPY) --reverse-bytes 4 -O verilog --verilog-data-width 4 $< $@
+	$(RISCV_OBJCOPY) -O verilog $< $@
 
 # keep dumps
 


### PR DESCRIPTION
objcopy with --verilog-data-width produces inconsistent byte ordering between different installs -> useless