### PR TITLE
croc: fix address to SRAM banks

### DIFF
--- a/ihp13/tc_clk.sv
+++ b/ihp13/tc_clk.sv
@@ -40,8 +40,8 @@ module tc_clk_mux2 (
   sg13g2_mux2_1 i_mux (
     .A0 ( clk0_i    ),
     .A1 ( clk1_i    ),
-    .S   ( clk_sel_i ),
-    .X   ( clk_o     )
+    .S  ( clk_sel_i ),
+    .X  ( clk_o     )
   );
 
 endmodule
@@ -54,12 +54,17 @@ module tc_clk_gating #(
     input  logic test_en_i,
     output logic clk_o
   );
-  (* keep *)(* dont_touch = "true" *)
-  sg13g2_slgcp_1 i_clkgate (
-    .GATE ( en_i ),
-    .SCE  ( test_en_i   ),
-    .CLK  ( clk_i ),
-    .GCLK ( clk_o )
-  );
+
+  if (IS_FUNCTIONAL || `ifdef USE_CLKGATE 1 `else 0 `endif) begin
+    (* keep *)(* dont_touch = "true" *)
+    sg13g2_slgcp_1 i_clkgate (
+      .GATE ( en_i  ),
+      .SCE  ( test_en_i ),
+      .CLK  ( clk_i ),
+      .GCLK ( clk_o )
+    );
+  end else begin
+    assign clk_o = clk_i;
+  end
 
 endmodule

--- a/ihp13/tc_sram.sv
+++ b/ihp13/tc_sram.sv
@@ -246,20 +246,21 @@ module tc_sram #(
     always_comb begin : gen_bit_interleaving
       for (int i = 0; i < 32; i++) begin
           // duplicate each bit
-          wdata64[2*i]   = wdata_i[0][i]; // even bits (active if addr MSB 0)
-          bm64[2*i]      = bm[0][i] & ~addr_i[0][8];
-          wdata64[2*i+1] = wdata_i[0][i]; // odd bits (active if addr MSB 1)
-          bm64[2*i+1]    = bm[0][i] & addr_i[0][8];
+          wdata64[2*i]   = wdata_i[0][i]; // even bits (active if addr LSB is 0)
+          bm64[2*i]      = bm[0][i] & ~addr_i[0][0];
+          wdata64[2*i+1] = wdata_i[0][i]; // odd bits  (active if addr LSB is 1)
+          bm64[2*i+1]    = bm[0][i] & addr_i[0][0];
 
           if(~sel_q) begin
-            rdata_o[0][i] = rdata64[2*i]; // even bits
+            rdata_o[0][i] = rdata64[2*i];   // even bits
           end else begin
             rdata_o[0][i] = rdata64[2*i+1]; // odd bits
           end
       end
     end
 
-    assign sel_d = addr_i[0][8];
+    // LSB needed for read in next cycle
+    assign sel_d = addr_i[0][0];
 
     always_ff @(posedge clk_i or negedge rst_ni) begin : proc_mem_sel_q
       if(~rst_ni)             sel_q <= '0;
@@ -268,7 +269,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_256x64_c2_bm_bist i_cut (
      .A_CLK   ( clk_i   ),
-     .A_ADDR  ( addr_i [0][7:0] ),
+     .A_ADDR  ( addr_i [0][8:1] ),
      .A_BM    ( bm64    ),
      .A_MEN   ( req_i   ),
      .A_WEN   ( we_i    ),

--- a/rtl/croc_domain.sv
+++ b/rtl/croc_domain.sv
@@ -310,7 +310,8 @@ module croc_domain import croc_pkg::*; #() (
 
   for (genvar i = 0; i < NumBanks; i++) begin : gen_sram_bank
     logic bank_req, bank_we, bank_gnt, bank_single_err;
-    logic [SbrObiCfg.DataWidth-1:0] bank_addr;
+    logic [SbrObiCfg.AddrWidth-1:0] bank_byte_addr;
+    logic [SbrObiCfg.AddrWidth-1-2:0] bank_word_addr;
     logic [SbrObiCfg.DataWidth-1:0] bank_wdata, bank_rdata;
     logic [SbrObiCfg.DataWidth/8-1:0] bank_be;
 
@@ -325,15 +326,17 @@ module croc_domain import croc_pkg::*; #() (
       .obi_req_i ( xbar_mem_bank_obi_req[i] ),
       .obi_rsp_o ( xbar_mem_bank_obi_rsp[i] ),
 
-      .req_o   ( bank_req   ),
-      .we_o    ( bank_we    ),
-      .addr_o  ( bank_addr  ),
-      .wdata_o ( bank_wdata ),
-      .be_o    ( bank_be    ),
+      .req_o   ( bank_req       ),
+      .we_o    ( bank_we        ),
+      .addr_o  ( bank_byte_addr ),
+      .wdata_o ( bank_wdata     ),
+      .be_o    ( bank_be        ),
 
       .gnt_i   ( bank_gnt   ),
       .rdata_i ( bank_rdata )
     );
+
+    assign bank_word_addr = bank_byte_addr[SbrObiCfg.AddrWidth-1:2];
 
     tc_sram #(
       .NumWords  ( BankNumWords ),
@@ -344,9 +347,9 @@ module croc_domain import croc_pkg::*; #() (
       .clk_i,
       .rst_ni,
 
-      .req_i   ( bank_req   ),
-      .we_i    ( bank_we    ),
-      .addr_i  ( bank_addr  ),
+      .req_i   ( bank_req       ),
+      .we_i    ( bank_we        ),
+      .addr_i  ( bank_word_addr ),
 
       .wdata_i ( bank_wdata ),
       .be_i    ( bank_be    ),


### PR DESCRIPTION
- Fix byte address instead of word address going to SRAMs (#15).
- Minor improvements for interleaving of SRAMs
- Minor improvements for synthesis
