### PR TITLE
hw: fix interrupt port width

### DIFF
--- a/rtl/core_wrap.sv
+++ b/rtl/core_wrap.sv
@@ -11,7 +11,7 @@ module core_wrap import croc_pkg::*; #() (
   input  logic ref_clk_i,
   input  logic test_enable_i,
 
-  input logic [14:0] irqs_i,
+  input logic [15:0] irqs_i,
   input logic timer0_irq_i,
 
   input  logic [31:0] boot_addr_i,
@@ -43,8 +43,6 @@ module core_wrap import croc_pkg::*; #() (
 
   output logic        core_busy_o
 );
-  // Interrupt signals
-  logic [31:0] core_irqs;
 
   // lowest 8 bits are ignored internally
   logic[31:0] ibex_boot_addr;

--- a/rtl/croc_domain.sv
+++ b/rtl/croc_domain.sv
@@ -55,7 +55,7 @@ module croc_domain import croc_pkg::*; #(
   logic gpio_irq;
   logic timer0_irq0;
   logic timer0_irq1;
-  logic [14:0] interrupts;
+  logic [15:0] interrupts;
   always_comb begin
     interrupts    = '0;
     interrupts[0] = timer0_irq1;


### PR DESCRIPTION
For some reason lowrisc ibex and cve2 do not agree on the number of irqs.