### PR TITLE
hw: fix gpio toggle

### DIFF
--- a/rtl/gpio/gpio_reg_top.sv
+++ b/rtl/gpio/gpio_reg_top.sv
@@ -125,7 +125,7 @@ module gpio_reg_top import gpio_reg_pkg::*; #(
       reg2hw[idx].dir         = reg_q.dir[idx];
       reg2hw[idx].en          = reg_q.en[idx];
       reg2hw[idx].out         = reg_q.out[idx];
-      reg2hw[idx].toggle      = toggle_out;
+      reg2hw[idx].toggle      = toggle_out[idx];
       reg2hw[idx].intrpt_en   = reg_q.intrpt_en[idx];
       reg2hw[idx].intrpt      = reg_q.intrpt[idx];
       reg2hw[idx].intrpt_edge = reg_q.intrpt_edge[idx];


### PR DESCRIPTION
previously it toggled all GPIOs, not just the ones selected, an obvious bug.