### PR TITLE
Fix unknown (X) in simulation

### DIFF
--- a/rtl/croc_chip.sv
+++ b/rtl/croc_chip.sv
@@ -128,10 +128,10 @@ module croc_chip import croc_pkg::*; #() (
     sg13g2_IOPadInOut30mA pad_gpio29_io    (.pad(gpio29_io),    .c2p(soc_gpio_o[29]), .p2c(soc_gpio_i[29]),  .c2p_en(soc_gpio_out_en_o[29]));
     sg13g2_IOPadInOut30mA pad_gpio30_io    (.pad(gpio30_io),    .c2p(soc_gpio_o[30]), .p2c(soc_gpio_i[30]),  .c2p_en(soc_gpio_out_en_o[30]));
     sg13g2_IOPadInOut30mA pad_gpio31_io    (.pad(gpio31_io),    .c2p(soc_gpio_o[31]), .p2c(soc_gpio_i[31]),  .c2p_en(soc_gpio_out_en_o[31]));
-    sg13g2_IOPadInOut30mA pad_unused0_o    (.pad(unused0_o),     .c2p(soc_status_o));
-    sg13g2_IOPadInOut30mA pad_unused1_o    (.pad(unused1_o),     .c2p(soc_status_o));
-    sg13g2_IOPadInOut30mA pad_unused2_o    (.pad(unused2_o),     .c2p(soc_status_o));
-    sg13g2_IOPadInOut30mA pad_unused3_o    (.pad(unused3_o),     .c2p(soc_status_o));
+    sg13g2_IOPadOut16mA pad_unused0_o      (.pad(unused0_o),    .c2p(soc_status_o));
+    sg13g2_IOPadOut16mA pad_unused1_o      (.pad(unused1_o),    .c2p(soc_status_o));
+    sg13g2_IOPadOut16mA pad_unused2_o      (.pad(unused2_o),    .c2p(soc_status_o));
+    sg13g2_IOPadOut16mA pad_unused3_o      (.pad(unused3_o),    .c2p(soc_status_o));
 
     (* dont_touch = "true" *)sg13g2_IOPadVdd pad_vdd0();
     (* dont_touch = "true" *)sg13g2_IOPadVdd pad_vdd1();

--- a/rtl/tb_croc_soc.sv
+++ b/rtl/tb_croc_soc.sv
@@ -36,7 +36,7 @@ module tb_croc_soc #(
     logic fetch_en_i;
     logic status_o;
 
-    localparam int unsigned GpioCount = 16;
+    localparam int unsigned GpioCount = 32;
 
     logic [GpioCount-1:0] gpio_i;             
     logic [GpioCount-1:0] gpio_o;            
@@ -456,21 +456,22 @@ module tb_croc_soc #(
         // init jtag
         jtag_init();
 
+        // write test value to sram
+        jtag_write_reg32(croc_pkg::SramBaseAddr, 32'h1234_5678, 1'b1);
+        // load binary to sram
+        jtag_load_hex(binary_path);
+
         $display("@%t | [CORE] Start fetching instructions", $time);
         fetch_en_i = 1'b1;
 
         // halt core
         jtag_halt();
 
-        // write test value to sram
-        jtag_write_reg32(croc_pkg::SramBaseAddr, 32'h1234_5678, 1'b1);
-        // load binary to sram
-        jtag_load_hex(binary_path);
-
         // resume core
         jtag_resume();
 
         // wait for non-zero return value (written into core status register)
+        $display("@%t | [CORE] Wait for end of code...", $time);
         jtag_wait_for_eoc(tb_data);
 
         // finish simulation


### PR DESCRIPTION
The memory was written to via JTAG only after the core was halted.
This causes the core to fetch X from memory and then propage it
through the entire design.
Now the memory is written before the HALT-RESUME test is performed.