### PR TITLE
Adjust memory map in sw/link.ld to 4k of SRAM for default config with 2 banks

### DIFF
--- a/sw/link.ld
+++ b/sw/link.ld
@@ -12,7 +12,7 @@ ENTRY(_start)
 
 MEMORY 
 {
-   SRAM (rwxail) : ORIGIN = 0x10000000, LENGTH = 2K
+   SRAM (rwxail) : ORIGIN = 0x10000000, LENGTH = 4K
 }
 
 SECTIONS


### PR DESCRIPTION
The default croc config has 2 banks of 512 32bit-words resulting in a total of 4096 bytes of SRAM.
The linker script sw/link.ld should set the SRAM length to 4k.