### PR TITLE
Openroad: Report final metrics

### DIFF
--- a/openroad/scripts/chip.tcl
+++ b/openroad/scripts/chip.tcl
@@ -279,6 +279,7 @@ utl::report "Filler placement"
 filler_placement $stdfill
 global_connect
 report_image "${proj_name}.final" true true false true
+report_metrics "${proj_name}.final"
 utl::report "Write output"
 write_def                      out/${proj_name}.def
 write_verilog -include_pwr_gnd out/${proj_name}_lvs.v


### PR DESCRIPTION
It would make sense to generate a final metric report before the results are written out.
This allows for easier comparison between different runs.