### PR TITLE
small bug correction in the gcc-options in the Makefile

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -58,10 +58,10 @@ $(BINDIR):
 	$(RISCV_CC) $(RISCV_CCFLAGS) -c $< -o $@
 
 $(BINDIR)/%.elf: %.S.o $(CRT0).o $(LIB_OBJS) | $(BINDIR)
-	$(RISCV_CC) $(RISCV_LDFLAGS) -o $@ $^ -T$(LINK)
+	$(RISCV_CC) -o $@ $^ $(RISCV_LDFLAGS) -T$(LINK)
 
 $(BINDIR)/%.elf: %.c.o $(CRT0).o $(LIB_OBJS) | $(BINDIR)
-	$(RISCV_CC) $(RISCV_LDFLAGS) -o $@ $^ -T$(LINK)
+	$(RISCV_CC) -o $@ $^ $(RISCV_LDFLAGS) -T$(LINK)
 
 $(BINDIR)/%.dump: $(BINDIR)/%.elf
 	$(RISCV_OBJDUMP) -D -s $< >$@


### PR DESCRIPTION
The options for the libraries like "-lgcc" have to be mentioned after the main code files and not bevor, as their functions are ignored otherwhise. ([https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#:~:text=It%20makes%20a%20difference%20where%20in%20the%20command%20you%20write%20this%20option](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#:~:text=It%20makes%20a%20difference%20where%20in%20the%20command%20you%20write%20this%20option))