### PR TITLE
openroad: set_propagated_clock after CTS

### DIFF
--- a/openroad/scripts/chip.tcl
+++ b/openroad/scripts/chip.tcl
@@ -210,6 +210,10 @@ utl::report "Detailed placement"
 detailed_placement {*}$DPL_ARGS
 utl::report "Estimate parasitics"
 estimate_parasitics -placement
+
+# propagate clocks now that we have a clock-tree
+set_propagated_clock [all_clocks]
+
 report_metrics "${log_id_str}_${proj_name}.cts_unrepaired"
 
 # repair all setup timing


### PR DESCRIPTION
In Exercise 7 we set all clocks to be propagated after we completed CTS.

We should also do this in the main branch. 