### PR TITLE
ci: fix artistic download artifact path

### DIFF
--- a/.github/workflows/artistic.yml
+++ b/.github/workflows/artistic.yml
@@ -46,7 +46,7 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run-id.outputs.run-id }}
-          path: klayout/croc_chip.gds
+          path: klayout
 
       - name: Checkout ArtistIC repository
         uses: actions/checkout@v4


### PR DESCRIPTION
I hope this finally fixes  the artistic CI.
I think `path:` specifies the directory not the file name and that is why it failed.