### PR TITLE
Add parasitic extraction (PEX) using ORFS rule file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,17 @@ default: help
 ################
 # Dependencies #
 ################
+# Download RCX file used for parasitic extraction from ORFS (configuration got ok by IHP)
+IHP_RCX_URL  := "https://raw.githubusercontent.com/The-OpenROAD-Project/OpenROAD-flow-scripts/7747f88f70daaeb63f43ce36e71829707b7e3fa7/flow/platforms/ihp-sg13g2/IHP_rcx_patterns.rules"
+IHP_RCX_FILE := $(PROJ_DIR)/openroad/IHP_rcx_patterns.rules
+
 ## Checkout/update dependencies using Bender
-checkout:
+checkout: $(IHP_RCX_FILE)
 	$(BENDER) checkout
 	git submodule update --init --recursive
+
+$(IHP_RCX_FILE): 
+	curl -L -o $@ $(IHP_RCX_URL)
 
 ## Reset dependencies (without updating Bender.lock)
 clean-deps:

--- a/openroad/.gitignore
+++ b/openroad/.gitignore
@@ -2,3 +2,4 @@
 save
 reports
 out
+IHP_rcx_patterns.rules

--- a/openroad/openroad.mk
+++ b/openroad/openroad.mk
@@ -29,7 +29,7 @@ backend: $(OR_OUT)/$(PROJ_NAME).def
 openroad: $(OR_OUT)/$(PROJ_NAME).def
 
 ## Place & Route flow using OpenROAD
-$(OR_OUT_FILES): $(NETLIST) $(OR_DIR)/scripts/*.tcl $(OR_DIR)/src/*.tcl $(OR_DIR)/src/*.sdc
+$(OR_OUT_FILES): $(NETLIST) $(OR_DIR)/scripts/*.tcl $(OR_DIR)/src/*.tcl $(OR_DIR)/src/*.sdc $(OR_DIR)/IHP_rcx_patterns.rules
 	mkdir -p $(SAVE)
 	mkdir -p $(REPORTS)
 	mkdir -p $(OR_OUT)

--- a/openroad/scripts/chip.tcl
+++ b/openroad/scripts/chip.tcl
@@ -343,7 +343,7 @@ report_metrics "${log_id_str}_${proj_name}.final"
 
 utl::report "Write output"
 write_def                      out/${proj_name}.def
-write_verilog -include_pwr_gnd out/${proj_name}_lvs.v
+write_verilog -include_pwr_gnd -remove_cells "$stdfill bondpad*" out/${proj_name}_lvs.v
 write_verilog                  out/${proj_name}.v
 write_db                       out/${proj_name}.odb
 write_sdc                      out/${proj_name}.sdc

--- a/openroad/scripts/chip.tcl
+++ b/openroad/scripts/chip.tcl
@@ -272,7 +272,7 @@ utl::report "Perform buffer insertion..."
 repair_design -verbose
 utl::report "Repair setup and hold violations..."
 repair_timing -skip_pin_swap -setup -verbose -repair_tns 100
-repair_timing -skip_pin_swap -hold -hold_margin 0.05 -verbose -repair_tns 100
+repair_timing -skip_pin_swap -hold -hold_margin 0.1 -verbose -repair_tns 100
 
 utl::report "GRT incremental..."
 # Run to get modified net by DPL
@@ -334,8 +334,12 @@ filler_placement $stdfill
 global_connect
 
 save_checkpoint ${log_id_str}_${proj_name}.final
-report_metrics "${log_id_str}_${proj_name}.final"
 report_image "${log_id_str}_${proj_name}.final" true true false true
+define_process_corner -ext_model_index 0 X
+extract_parasitics -ext_model_file IHP_rcx_patterns.rules
+write_spef out/${proj_name}.spef
+read_spef  out/${proj_name}.spef; # readback parasitics for OpenSTA
+report_metrics "${log_id_str}_${proj_name}.final"
 
 utl::report "Write output"
 write_def                      out/${proj_name}.def

--- a/yosys/scripts/yosys_common.tcl
+++ b/yosys/scripts/yosys_common.tcl
@@ -13,7 +13,6 @@
 set variables {
     sv_flist    { SV_FLIST    "../croc.flist" }
     top_design  { TOP_DESIGN  "croc_chip"     }
-    period_ps   { PERIOD_PS   10000           }
     out_dir     { OUT         out             }
     tmp_dir     { TMP         tmp             }
     rep_dir     { REPORTS     reports         }
@@ -48,6 +47,7 @@ proc processAbcScript {abc_script} {
     set src_dir [file join [file dirname [info script]] ../src]
     set abc_out_path $tmp_dir/[file tail $abc_script]
 
+    # substitute {STRING} placeholders with their value
     set raw [read -nonewline [open $abc_script r]]
     set abc_script_recaig [string map -nocase [list "{REC_AIG}" [subst "$src_dir/lazy_man_synth_library.aig"]] $raw]
     set abc_out [open $abc_out_path w]

--- a/yosys/scripts/yosys_synthesis.tcl
+++ b/yosys/scripts/yosys_synthesis.tcl
@@ -133,6 +133,7 @@ yosys tee -q -a ${rep_dir}/${top_design}_instances.rpt  select -list "t:tc_clk*$
 yosys dfflibmap {*}$tech_cells_args
 
 # then perform bit-level optimization and mapping on all combinational clouds in ABC
+# target period (per optimized block/module) in picoseconds
 set period_ps 10000
 # pre-process abc file (written to tmp directory)
 set abc_comb_script   [processAbcScript scripts/abc-opt.script]

--- a/yosys/yosys.mk
+++ b/yosys/yosys.mk
@@ -17,8 +17,6 @@ YOSYS_REPORTS	:= $(YOSYS_DIR)/reports
 
 # top level to be synthesized
 TOP_DESIGN		?= croc_chip
-# target period in picoseconds
-PERIOD_PS		?= 10000
 
 # file containing include dirs, defines and paths to all source files
 SV_FLIST    	:= $(realpath $(YOSYS_DIR)/..)/croc.flist
@@ -38,7 +36,6 @@ $(NETLIST) $(NETLIST_DEBUG):  $(SV_FLIST)
 	cd $(YOSYS_DIR) && \
 	SV_FLIST="$(SV_FLIST)" \
 	TOP_DESIGN="$(TOP_DESIGN)" \
-	PERIOD_PS="$(PERIOD_PS)" \
 	TMP="$(YOSYS_TMP)" \
 	OUT="$(YOSYS_OUT)" \
 	REPORTS="$(YOSYS_REPORTS)" \


### PR DESCRIPTION
This closely follows openroad-flow-scripts approach and uses the RCX file from their repo.  
This rules files has been okayed by IHP and should produce proper results.