### PR TITLE
hw: configurable A_DLY SRAM pin

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -26,7 +26,7 @@ sources:
   - target: ihp13
     files:
       - ihp13/tc_clk.sv
-      - ihp13/tc_sram.sv
+      - ihp13/tc_sram_impl.sv
 
   - rtl/croc_pkg.sv
   - rtl/user_pkg.sv

--- a/croc.flist
+++ b/croc.flist
@@ -174,7 +174,7 @@ rtl/timer_unit/timer_unit_counter_presc.sv
 rtl/timer_unit/apb_timer_unit.sv
 rtl/timer_unit/timer_unit.sv
 ihp13/tc_clk.sv
-ihp13/tc_sram.sv
+ihp13/tc_sram_impl.sv
 rtl/croc_pkg.sv
 rtl/user_pkg.sv
 rtl/soc_ctrl/soc_ctrl_reg_pkg.sv

--- a/ihp13/tc_sram_impl.sv
+++ b/ihp13/tc_sram_impl.sv
@@ -28,8 +28,7 @@ endmodule
   .A_BIST_MEN   (  1'b0 ), \
   .A_BIST_WEN   (  1'b0 ), \
   .A_BIST_REN   (  1'b0 ), \
-  .A_BIST_EN    (  1'b0 ), \
-  .A_DLY        (  1'b0 )
+  .A_BIST_EN    (  1'b0 )
 
 `define IHP13_TC_SRAM_256x64_TIEOFF \
   .A_BIST_CLK   (  1'b0 ), \
@@ -39,8 +38,7 @@ endmodule
   .A_BIST_MEN   (  1'b0 ), \
   .A_BIST_WEN   (  1'b0 ), \
   .A_BIST_REN   (  1'b0 ), \
-  .A_BIST_EN    (  1'b0 ), \
-  .A_DLY        (  1'b0 )
+  .A_BIST_EN    (  1'b0 )
 
 `define IHP13_TC_SRAM_512x64_TIEOFF \
   .A_BIST_CLK   (  1'b0 ), \
@@ -50,8 +48,7 @@ endmodule
   .A_BIST_MEN   (  1'b0 ), \
   .A_BIST_WEN   (  1'b0 ), \
   .A_BIST_REN   (  1'b0 ), \
-  .A_BIST_EN    (  1'b0 ), \
-  .A_DLY        (  1'b0 )
+  .A_BIST_EN    (  1'b0 )
 
 `define IHP13_TC_SRAM_1024x64_TIEOFF \
   .A_BIST_CLK   (  1'b0 ), \
@@ -61,8 +58,7 @@ endmodule
   .A_BIST_MEN   (  1'b0 ), \
   .A_BIST_WEN   (  1'b0 ), \
   .A_BIST_REN   (  1'b0 ), \
-  .A_BIST_EN    (  1'b0 ), \
-  .A_DLY        (  1'b0 )
+  .A_BIST_EN    (  1'b0 )
 
 `define IHP13_TC_SRAM_2048x64_TIEOFF \
   .A_BIST_CLK   (  1'b0 ), \
@@ -72,10 +68,9 @@ endmodule
   .A_BIST_MEN   (  1'b0 ), \
   .A_BIST_WEN   (  1'b0 ), \
   .A_BIST_REN   (  1'b0 ), \
-  .A_BIST_EN    (  1'b0 ), \
-  .A_DLY        (  1'b0 )
+  .A_BIST_EN    (  1'b0 )
 
-module tc_sram #(
+module tc_sram_impl #(
   parameter int unsigned NumWords     = 32'd1024,
   parameter int unsigned DataWidth    = 32'd128,
   parameter int unsigned ByteWidth    = 32'd8,
@@ -84,6 +79,9 @@ module tc_sram #(
   parameter              SimInit      = "none",
   parameter bit          PrintSimCfg  = 1'b0,
   parameter              ImplKey      = "none",
+  parameter type         impl_in_t    = logic,
+  parameter type         impl_out_t   = logic,
+  parameter impl_out_t   ImplOutSim   = 'X,
   // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
   parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
   parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth,
@@ -93,11 +91,16 @@ module tc_sram #(
 ) (
   input  logic                 clk_i,
   input  logic                 rst_ni,
+
+  input  impl_in_t             impl_i,
+  output impl_out_t            impl_o,
+
   input  logic  [NumPorts-1:0] req_i,
   input  logic  [NumPorts-1:0] we_i,
   input  addr_t [NumPorts-1:0] addr_i,
   input  data_t [NumPorts-1:0] wdata_i,
   input  be_t   [NumPorts-1:0] be_i,
+
   output data_t [NumPorts-1:0] rdata_o
 );
 
@@ -112,6 +115,9 @@ module tc_sram #(
       end
   end
 
+  // We drive a static value for `impl_o` in behavioral simulation.
+  assign impl_o = ImplOutSim;
+
   // Generate desired cuts
   if (NumWords == 64 && DataWidth == 64 && P1L1) begin: gen_64x64xBx1
     logic [63:0] wdata64, rdata64, bm64;
@@ -123,6 +129,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_64x64_c2_bm_bist i_cut (
       .A_CLK   ( clk_i    ),
+      .A_DLY   ( impl_i  ),
       .A_ADDR  ( addr_i [0][5:0] ),
       .A_BM    ( bm64     ),
       .A_MEN   ( req_i    ),
@@ -142,6 +149,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_256x64_c2_bm_bist i_cut (
       .A_CLK   ( clk_i    ),
+      .A_DLY   ( impl_i  ),
       .A_ADDR  ( addr_i [0][7:0] ),
       .A_BM    ( bm64     ),
       .A_MEN   ( req_i    ),
@@ -161,6 +169,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_512x64_c2_bm_bist i_cut (
       .A_CLK   ( clk_i    ),
+      .A_DLY   ( impl_i  ),
       .A_ADDR  ( addr_i [0][8:0] ),
       .A_BM    ( bm64     ),
       .A_MEN   ( req_i    ),
@@ -180,6 +189,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_1024x64_c2_bm_bist i_cut (
        .A_CLK   ( clk_i    ),
+       .A_DLY   ( impl_i  ),
        .A_ADDR  ( addr_i [0][9:0] ),
        .A_BM    ( bm64     ),
        .A_MEN   ( req_i    ),
@@ -199,6 +209,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_2048x64_c2_bm_bist i_cut (
        .A_CLK   ( clk_i    ),
+       .A_DLY   ( impl_i   ),
        .A_ADDR  ( addr_i [0][10:0] ),
        .A_BM    ( bm64     ),
        .A_MEN   ( req_i    ),
@@ -239,6 +250,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_256x64_c2_bm_bist i_cut (
      .A_CLK   ( clk_i   ),
+     .A_DLY   ( impl_i  ),
      .A_ADDR  ( addr_i [0][8:1] ),
      .A_BM    ( bm64    ),
      .A_MEN   ( req_i   ),
@@ -280,6 +292,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_512x64_c2_bm_bist i_cut (
      .A_CLK   ( clk_i   ),
+     .A_DLY   ( impl_i  ),
      .A_ADDR  ( addr_i [0][9:1] ),
      .A_BM    ( bm64    ),
      .A_MEN   ( req_i   ),
@@ -320,6 +333,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_1024x64_c2_bm_bist i_cut (
      .A_CLK   ( clk_i   ),
+     .A_DLY   ( impl_i  ),
      .A_ADDR  ( addr_i [0][10:1] ),
      .A_BM    ( bm64    ),
      .A_MEN   ( req_i   ),
@@ -339,6 +353,7 @@ module tc_sram #(
 
     RM_IHPSG13_1P_2048x64_c2_bm_bist i_cut (
        .A_CLK   ( clk_i    ),
+       .A_DLY   ( impl_i   ),
        .A_ADDR  ( addr_i [0][10:0] ),
        .A_BM    ( bm64     ),
        .A_MEN   ( req_i    ),

--- a/openroad/src/instances.tcl
+++ b/openroad/src/instances.tcl
@@ -30,8 +30,6 @@ set sram {\[0\].i_sram/}
 set bank0_sram0 $SRAM$sram$SRAM_512x32
 set sram {\[1\].i_sram/}
 set bank1_sram0 $SRAM$sram$SRAM_512x32
-set sram {\[2\].i_sram/}
-set bank2_sram0 $SRAM$sram$SRAM_512x32
 
 set JTAG_ASYNC_REQ [get_nets $JTAG/i_dmi_cdc.i_cdc_req/*async_*]
 set JTAG_ASYNC_RSP [get_nets $JTAG/i_dmi_cdc.i_cdc_resp/*async_*]

--- a/rtl/croc_domain.sv
+++ b/rtl/croc_domain.sv
@@ -46,6 +46,7 @@ module croc_domain import croc_pkg::*; #(
   // -----------------
   // Control Signals
   // -----------------
+  logic sram_impl; // soc_ctrl -> SRAM config signals
   logic debug_req;
   logic fetch_enable;
   logic [31:0] boot_addr;
@@ -368,7 +369,7 @@ module croc_domain import croc_pkg::*; #(
 
     assign bank_word_addr = bank_byte_addr[SbrObiCfg.AddrWidth-1:2];
 
-    tc_sram #(
+    tc_sram_impl #(
       .NumWords  ( SramBankNumWords ),
       .DataWidth ( 32 ),
       .NumPorts  (  1 ),
@@ -376,6 +377,9 @@ module croc_domain import croc_pkg::*; #(
     ) i_sram (
       .clk_i,
       .rst_ni,
+
+      .impl_i  ( sram_impl      ),
+      .impl_o  ( ), // not connected
 
       .req_i   ( bank_req       ),
       .we_i    ( bank_we        ),
@@ -497,8 +501,9 @@ module croc_domain import croc_pkg::*; #(
 
   soc_ctrl_reg_pkg::soc_ctrl_reg2hw_t soc_ctrl_reg2hw;
   soc_ctrl_reg_pkg::soc_ctrl_hw2reg_t soc_ctrl_hw2reg;
-  assign fetch_enable = soc_ctrl_reg2hw.fetchen.q | fetch_en_i;
-  assign boot_addr = soc_ctrl_reg2hw.bootaddr.q;
+  assign fetch_enable    = soc_ctrl_reg2hw.fetchen.q | fetch_en_i;
+  assign boot_addr       = soc_ctrl_reg2hw.bootaddr.q;
+  assign sram_impl       = soc_ctrl_reg2hw.sram_dly;
   assign soc_ctrl_hw2reg = '0;
 
   soc_ctrl_reg_top #(

--- a/rtl/soc_ctrl/soc_ctrl.html
+++ b/rtl/soc_ctrl/soc_ctrl.html
@@ -1,64 +1,93 @@
-<!DOCTYPE html>
-<html>
-<head>
-<link rel=stylesheet href=reg_html.css>
-</head>
-<table class="regdef" id="Reg_bootaddr">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>soc_ctrl.bootaddr @ 0x0</div>
-   <div><p>Core Boot Address</p></div>
-   <div>Reset default = 0x1a000000, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>bootaddr...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...bootaddr</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1a000000</td><td class="regfn">bootaddr</td><td class="regde"><p>Boot Address</p></td></table>
-<br>
-<table class="regdef" id="Reg_fetchen">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>soc_ctrl.fetchen @ 0x4</div>
-   <div><p>Core Fetch Enable</p></div>
-   <div>Reset default = 0x0, mask 0x1</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="unused" colspan=16>&nbsp;</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="unused" colspan=15>&nbsp;</td>
-<td class="fname" colspan=1 style="font-size:42.857142857142854%">fetchen</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">fetchen</td><td class="regde"><p>Fetch Enable</p></td></table>
-<br>
-<table class="regdef" id="Reg_corestatus">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>soc_ctrl.corestatus @ 0x8</div>
-   <div><p>Core Return Status (return value, EOC)</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>core_status...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...core_status</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">core_status</td><td class="regde"><p>Core Return Status (EOC(bit[31]) and status(bit[30:0]))</p></td></table>
-<br>
-<table class="regdef" id="Reg_bootmode">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>soc_ctrl.bootmode @ 0xc</div>
-   <div><p>Core Boot Mode</p></div>
-   <div>Reset default = 0x0, mask 0x1</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="unused" colspan=16>&nbsp;</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="unused" colspan=14>&nbsp;</td>
-<td class="fname" colspan=2 style="font-size:75.0%">bootmode</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">1:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">bootmode</td><td class="regde"><p>Boot Mode</p></td></table>
-<br>
-</html>
+## Summary
+
+| Name                                 | Offset   |   Length | Description                            |
+|:-------------------------------------|:---------|---------:|:---------------------------------------|
+| soc_ctrl.[`bootaddr`](#bootaddr)     | 0x0      |        4 | Core Boot Address                      |
+| soc_ctrl.[`fetchen`](#fetchen)       | 0x4      |        4 | Core Fetch Enable                      |
+| soc_ctrl.[`corestatus`](#corestatus) | 0x8      |        4 | Core Return Status (return value, EOC) |
+| soc_ctrl.[`bootmode`](#bootmode)     | 0xc      |        4 | Core Boot Mode                         |
+| soc_ctrl.[`sram_dly`](#sram_dly)     | 0x10     |        4 | SRAM A_DLY value                       |
+
+## bootaddr
+Core Boot Address
+- Offset: `0x0`
+- Reset default: `0x10000000`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "bootaddr", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |   Reset    | Name     | Description   |
+|:------:|:------:|:----------:|:---------|:--------------|
+|  31:0  |   rw   | 0x10000000 | bootaddr | Boot Address  |
+
+## fetchen
+Core Fetch Enable
+- Offset: `0x4`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "fetchen", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 90}}
+```
+
+|  Bits  |  Type  |  Reset  | Name    | Description   |
+|:------:|:------:|:-------:|:--------|:--------------|
+|  31:1  |        |         |         | Reserved      |
+|   0    |   rw   |   0x0   | fetchen | Fetch Enable  |
+
+## corestatus
+Core Return Status (return value, EOC)
+- Offset: `0x8`
+- Reset default: `0x0`
+- Reset mask: `0xffffffff`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "core_status", "bits": 32, "attr": ["rw"], "rotate": 0}], "config": {"lanes": 1, "fontsize": 10, "vspace": 80}}
+```
+
+|  Bits  |  Type  |  Reset  | Name        | Description                                             |
+|:------:|:------:|:-------:|:------------|:--------------------------------------------------------|
+|  31:0  |   rw   |   0x0   | core_status | Core Return Status (EOC(bit[31]) and status(bit[30:0])) |
+
+## bootmode
+Core Boot Mode
+- Offset: `0xc`
+- Reset default: `0x0`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "bootmode", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 100}}
+```
+
+|  Bits  |  Type  |  Reset  | Name     | Description   |
+|:------:|:------:|:-------:|:---------|:--------------|
+|  31:1  |        |         |          | Reserved      |
+|   0    |   rw   |   0x0   | bootmode | Boot Mode     |
+
+## sram_dly
+SRAM A_DLY value
+- Offset: `0x10`
+- Reset default: `0x1`
+- Reset mask: `0x1`
+
+### Fields
+
+```wavejson
+{"reg": [{"name": "sram_dly", "bits": 1, "attr": ["rw"], "rotate": -90}, {"bits": 31}], "config": {"lanes": 1, "fontsize": 10, "vspace": 100}}
+```
+
+|  Bits  |  Type  |  Reset  | Name     | Description                                                       |
+|:------:|:------:|:-------:|:---------|:------------------------------------------------------------------|
+|  31:1  |        |         |          | Reserved                                                          |
+|   0    |   rw   |   0x1   | sram_dly | Controls the A_DLY pin of the SRAMs (configured internal timings) |
+

--- a/rtl/soc_ctrl/soc_ctrl_reg_pkg.sv
+++ b/rtl/soc_ctrl/soc_ctrl_reg_pkg.sv
@@ -7,7 +7,7 @@
 package soc_ctrl_reg_pkg;
 
   // Address widths within the block
-  parameter int BlockAw = 4;
+  parameter int BlockAw = 5;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -30,6 +30,10 @@ package soc_ctrl_reg_pkg;
   } soc_ctrl_reg2hw_bootmode_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } soc_ctrl_reg2hw_sram_dly_reg_t;
+
+  typedef struct packed {
     logic        d;
     logic        de;
   } soc_ctrl_hw2reg_fetchen_reg_t;
@@ -44,35 +48,39 @@ package soc_ctrl_reg_pkg;
     soc_ctrl_reg2hw_bootaddr_reg_t bootaddr; // [66:35]
     soc_ctrl_reg2hw_fetchen_reg_t fetchen; // [34:34]
     soc_ctrl_reg2hw_corestatus_reg_t corestatus; // [33:2]
-    soc_ctrl_reg2hw_bootmode_reg_t bootmode; // [1:0]
+    soc_ctrl_reg2hw_bootmode_reg_t bootmode; // [1:1]
+    soc_ctrl_reg2hw_sram_dly_reg_t sram_dly; // [0:0]
   } soc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    soc_ctrl_hw2reg_fetchen_reg_t fetchen; // [4:3]
-    soc_ctrl_hw2reg_bootmode_reg_t bootmode; // [2:0]
+    soc_ctrl_hw2reg_fetchen_reg_t fetchen; // [3:2]
+    soc_ctrl_hw2reg_bootmode_reg_t bootmode; // [1:0]
   } soc_ctrl_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] SOC_CTRL_BOOTADDR_OFFSET = 4'h 0;
-  parameter logic [BlockAw-1:0] SOC_CTRL_FETCHEN_OFFSET = 4'h 4;
-  parameter logic [BlockAw-1:0] SOC_CTRL_CORESTATUS_OFFSET = 4'h 8;
-  parameter logic [BlockAw-1:0] SOC_CTRL_BOOTMODE_OFFSET = 4'h c;
+  parameter logic [BlockAw-1:0] SOC_CTRL_BOOTADDR_OFFSET = 5'h 0;
+  parameter logic [BlockAw-1:0] SOC_CTRL_FETCHEN_OFFSET = 5'h 4;
+  parameter logic [BlockAw-1:0] SOC_CTRL_CORESTATUS_OFFSET = 5'h 8;
+  parameter logic [BlockAw-1:0] SOC_CTRL_BOOTMODE_OFFSET = 5'h c;
+  parameter logic [BlockAw-1:0] SOC_CTRL_SRAM_DLY_OFFSET = 5'h 10;
 
   // Register index
   typedef enum int {
     SOC_CTRL_BOOTADDR,
     SOC_CTRL_FETCHEN,
     SOC_CTRL_CORESTATUS,
-    SOC_CTRL_BOOTMODE
+    SOC_CTRL_BOOTMODE,
+    SOC_CTRL_SRAM_DLY
   } soc_ctrl_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SOC_CTRL_PERMIT [4] = '{
+  parameter logic [3:0] SOC_CTRL_PERMIT [5] = '{
     4'b 1111, // index[0] SOC_CTRL_BOOTADDR
     4'b 0001, // index[1] SOC_CTRL_FETCHEN
     4'b 1111, // index[2] SOC_CTRL_CORESTATUS
-    4'b 0001  // index[3] SOC_CTRL_BOOTMODE
+    4'b 0001, // index[3] SOC_CTRL_BOOTMODE
+    4'b 0001  // index[4] SOC_CTRL_SRAM_DLY
   };
 
 endpackage

--- a/rtl/soc_ctrl/soc_ctrl_regs.hjson
+++ b/rtl/soc_ctrl/soc_ctrl_regs.hjson
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: SHL-0.51
 
 {
-  name: "safety_soc_ctrl",
+  name: "soc_ctrl",
   clock_primary: "clk_i",
   reset_primary: "rst_ni",
   bus_interfaces: [
@@ -50,7 +50,7 @@
           resval: 0
         }
       ]
-    }
+    },
     { name: "bootmode",
       desc: "Core Boot Mode",
       swaccess: "rw",
@@ -62,7 +62,19 @@
           resval: 0x0
         }
       ]
-
     },
+    { name: "sram_dly",
+      desc: "SRAM A_DLY value",
+      swaccess: "rw",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          name: "sram_dly",
+          desc: "Controls the A_DLY pin of the SRAMs (configured internal timings)",
+          resval: 0x1
+        }
+      ]
+    }
+
   ],
 }

--- a/yosys/scripts/yosys_synthesis.tcl
+++ b/yosys/scripts/yosys_synthesis.tcl
@@ -44,7 +44,7 @@ yosys setattr -set keep_hierarchy 1 "t:timer_unit$*"
 yosys setattr -set keep_hierarchy 1 "t:reg_uart_wrap$*"
 yosys setattr -set keep_hierarchy 1 "t:soc_ctrl_reg_top$*"
 yosys setattr -set keep_hierarchy 1 "t:tc_clk*$*"
-yosys setattr -set keep_hierarchy 1 "t:tc_sram$*"
+yosys setattr -set keep_hierarchy 1 "t:tc_sram_impl$*"
 yosys setattr -set keep_hierarchy 1 "t:cdc_*$*"
 yosys setattr -set keep_hierarchy 1 "t:sync$*"
 


### PR DESCRIPTION
Documentation says it must be tied to HIGH.
This was mistakenly tied low which changes the internal timings of the SRAM and can make some of them inoperable. Now it is configurable in soc_ctrl.