### PR TITLE
hw: fix stimuli application and sampling times

### DIFF
--- a/rtl/tb_croc_soc.sv
+++ b/rtl/tb_croc_soc.sv
@@ -11,8 +11,8 @@ module tb_croc_soc #(
     parameter time         ClkPeriod     = 50ns,
     parameter time         ClkPeriodJtag = 50ns,
     parameter time         ClkPeriodRef  = 30518ns,
-    parameter time         TAppl         = 0.2*ClkPeriod,
-    parameter time         TTest         = 0.8*ClkPeriod,
+    parameter time         TAppl         = 0.2*ClkPeriodJtag,
+    parameter time         TTest         = 0.8*ClkPeriodJtag,
     parameter int unsigned RstCycles     = 1,
     // UART
     parameter int unsigned  UartBaudRate      = 115200,


### PR DESCRIPTION
Changing the clock frequency of JTAG and system clocks independently may not work because the application and sampling times are relative to the system clock period, but are applied to signals clocked with the JTAG clock.