### PR TITLE
hw: decouple obi req and gnt (spec: R-22)

### DIFF
--- a/rtl/croc_domain.sv
+++ b/rtl/croc_domain.sv
@@ -390,7 +390,7 @@ module croc_domain import croc_pkg::*; #(
       .rdata_o ( bank_rdata )
     );
 
-    assign bank_gnt = 1'b1;
+    assign bank_gnt = 1'b1; // always ready for request
   end
 
 

--- a/rtl/gpio/gpio_reg_top.sv
+++ b/rtl/gpio/gpio_reg_top.sv
@@ -60,7 +60,7 @@ module gpio_reg_top import gpio_reg_pkg::*; #(
     obi_rsp_o.r.rdata      = obi_rdata;
     obi_rsp_o.r.rid        = id_q;
     obi_rsp_o.r.err        = obi_err;
-    obi_rsp_o.gnt          = obi_req_i.req;
+    obi_rsp_o.gnt          = '1; // always ready for request
     obi_rsp_o.rvalid       = valid_q;
   end
 
@@ -163,7 +163,7 @@ module gpio_reg_top import gpio_reg_pkg::*; #(
     // WRITE
     //---------------------------------------------------------------------------------
     if (obi_write_request) begin
-      obi_err = 1'b0;
+      w_err_d = 1'b0;
       case ({write_addr, 2'b00})
         GPIO_DIR_OFFSET: begin
           reg_d.dir = (~bit_mask & new_reg.dir) | (bit_mask & obi_wdata[GpioCount-1:0]);

--- a/rtl/obi_uart/obi_uart_register.sv
+++ b/rtl/obi_uart/obi_uart_register.sv
@@ -48,7 +48,7 @@ module obi_uart_register import obi_uart_pkg::*; #(
     obi_rsp_o.r.rdata = rsp_data;
     obi_rsp_o.r.rid   = id_q;
     obi_rsp_o.r.err   = err;
-    obi_rsp_o.gnt     = obi_req_i.req;
+    obi_rsp_o.gnt     = '1; // always ready for request
     obi_rsp_o.rvalid  = valid_q;
   end
 


### PR DESCRIPTION
Decouples OBI request and grant signals in the SRAM, GPIO and UART peripherals.  
This decreases the total path length through the interconnect and can increase the operating frequency.