### PR TITLE
scripts: fix mounted directory in start_vnc

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ This should connect you to the VNC server, the password is `abc123`, then test b
 You should see the files in this repository again.
 
 Now you should be in an Ubuntu environment with all tools pre-installed for you.  
-If something does not work, refer to the upstream [IIC-OSIC-Tools](https://github.com/iic-jku/IIC-OSIC-TOOLS/tree/main)
+If something does not work, refer to the upstream [IIC-OSIC-Tools](https://github.com/iic-jku/IIC-OSIC-TOOLS/tree/main).
+
+To stop the VNC server, run the start script again and then select between stopping or stop and remove the running docker container.
 
 #### Native install (hard)
 

--- a/scripts/start_vnc.bat
+++ b/scripts/start_vnc.bat
@@ -19,7 +19,7 @@ REM ========================================================================
 
 SETLOCAL
 
-SET DESIGNS=%~dp0
+SET DESIGNS=%~dp0..
 REM Convert Windows path to Unix style for Docker compatibility
 FOR /f "tokens=1,* delims=:" %%A IN ("%DESIGNS%") DO (
     SET DRIVE_LETTER=%%A

--- a/scripts/start_vnc.sh
+++ b/scripts/start_vnc.sh
@@ -25,7 +25,7 @@ if [ -n "${DRY_RUN}" ]; then
 fi
 
 # SET YOUR DESIGN PATH RIGHT!
-DESIGNS="$(realpath $(dirname "${BASH_SOURCE[0]}"))"
+DESIGNS="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
 
 if [ -z ${DESIGNS+z} ]; then
 	DESIGNS=$HOME/eda/designs


### PR DESCRIPTION
The `start_vnc` scripts mount the `scripts/` directory instead of `./` since they have been moved.  
This changes it back to `./`.