### PR TITLE
Patch linker script to force keeping vectors section

### DIFF
--- a/sw/link.ld
+++ b/sw/link.ld
@@ -38,6 +38,7 @@ SECTIONS
 	.vectors : ALIGN(4)
 	{
 	*(.vectors)
+	KEEP(*(.vectors))
 	} > SRAM :text
 
     /* Startup entry (first instructions executed after bootrom) */


### PR DESCRIPTION
Make sure that the `.vectors` section is not garbage collected (even if gc is enabled in linker options). This is necessary as the bootrom assumes that the exception and interrupt handler addresses are stored at the beginning of the SRAM.

Thanks @creinwar :)

